### PR TITLE
Fix link to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Taxi is a toy esoteric language. See the [classic Taxi webpage](http://bigzaphod.github.com/Taxi/) for more info!
+Taxi is a toy esoteric language. See the [classic Taxi webpage](http://bigzaphod.github.io/Taxi/) for more info!


### PR DESCRIPTION
Links to GitHub pages should now point to `github.io` instead of `github.com`.  This fixes the link in the readme.

Compare [original](http://bigzaphod.github.com/Taxi/) leading to 404, with [corrected](http://bigzaphod.github.io/Taxi/).